### PR TITLE
Bug fix: crash in export_csv

### DIFF
--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -1017,7 +1017,7 @@ def export_sqlite():
 
 
 def export_csv():
-    with get_engine(schema).begin() as connection, zipfile.ZipFile(f"{output_dir}/iati_csv.zip", "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+    with get_engine().begin() as connection, zipfile.ZipFile(f"{output_dir}/iati_csv.zip", "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
         result = list(
             connection.execute(
                 "SELECT table_name FROM _tables"


### PR DESCRIPTION
export_csv was passing schema to get_engine and the first parameter of get_engine is db_uri. Crashes with:
sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from string 'iati'

https://github.com/codeforIATI/iati-tables/issues/15