### PR TITLE
site: Fixes to local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,29 @@ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt install nodejs
 ```
 
-Then:
+Install yarn:
 
 ```
 sudo npm install -g yarn
+```
+
+Install dependencies:
+
+```
 cd site
 yarn install
-NODE_OPTIONS="--openssl-legacy-provider" yarn build
 ```
 
-Server the site/dist directory on the root of a webserver.
-
-e.g. for development:
+Start the development server:
 
 ```
+yarn serve
+```
+
+Build and view the site:
+
+```
+yarn build
 cd site/dist
 python3 -m http.server --bind 127.0.0.1 8000
 ```

--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/site/src/views/Home.vue
+++ b/site/src/views/Home.vue
@@ -70,7 +70,7 @@
           </v-card-title >
           <v-card-text >
             <p>IATI data has been transfromed into tables in order to make it easier to work with relational tools.  Below is the list of tables that have been created. Click on them to see the fields and types within.</p>
-            <p><b>Last Update:</b> {{stats.updated.substring(0, 16)}}</p>
+            <p><b>Last Update:</b> {{lastUpdated}}</p>
           </v-card-text>
         </v-card>
       </v-col>
@@ -146,7 +146,8 @@ export default {
   name: 'Home',
   components: { TableModal },
   data: () => ({
-    stats: { tables: [] }
+    stats: { tables: [] },
+    lastUpdated: 'Unavailable'
   }),
   created: function () {
     this.fetchStats()
@@ -161,6 +162,8 @@ export default {
       const response = await fetch('https://iati.fra1.digitaloceanspaces.com/stats.json')
       const stats = await response.json()
       this.stats = stats
+      const lastUpdated = new Date(stats.updated)
+      this.lastUpdated = lastUpdated.toGMTString()
       // this.$nextTick(() => VueScrollTo.scrollTo(window.location.hash))
     },
     scrollDone: function (el) {

--- a/site/src/views/Home.vue
+++ b/site/src/views/Home.vue
@@ -69,7 +69,7 @@
             About
           </v-card-title >
           <v-card-text >
-            <p>IATI data has been transfromed into tables in order to make it easier to work with relational tools.  Below is the list of tables that have been created. Click on them to see the fields and types within.</p>
+            <p>IATI data has been transformed into tables in order to make it easier to work with relational tools.  Below is the list of tables that have been created. Click on them to see the fields and types within.</p>
             <p><b>Last Update:</b> {{lastUpdated}}</p>
           </v-card-text>
         </v-card>


### PR DESCRIPTION
- Move `NODE_OPTIONS=--openssl-legacy-provider` into yarn scripts so developer doesn't have to add them when running the site
- Add default value for last updated time, to avoid local development failing when it can't access the data
- Add timezone (GMT) to last updated time on the site, to be more useful for users
- Update readme