### PR TITLE
logging: Fix logging error

### DIFF
--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -286,8 +286,8 @@ def save_part(data):
 
                 try:
                     root = dataset.etree.getroot()
-                except Exception as e:
-                    logger.error("Error parsing XML", e)
+                except Exception:
+                    logger.exception("Error parsing XML")
                     continue
 
                 save_converted_xml_to_csv(root, csv_file, prefix, filename)


### PR DESCRIPTION
I missed this exception log when testing locally but it came up in last night's run, passing too many args to `logger.error()`, have changed to `logger.exception()` which will log the stack trace after the message