### PR TITLE
Retry downloading schema and registry data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ googleapis-common-protos==1.62.0
     # via google-api-core
 greenlet==3.0.3
     # via sqlalchemy
-iatikit==3.3.1
+iatikit==3.4.0
     # via -r requirements.in
 idna==3.6
     # via requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -85,7 +85,7 @@ googleapis-common-protos==1.62.0
     #   google-api-core
 greenlet==3.0.3
     # via -r requirements.txt
-iatikit==3.3.1
+iatikit==3.4.0
     # via -r requirements.txt
 idna==3.6
     # via


### PR DESCRIPTION
Upgrade `iatikit` to `3.4.0` to add retries for schema/data downloads.

Closes https://github.com/codeforIATI/iati-tables/issues/37