### PR TITLE
site: Remove table row count filter from site homepage

### DIFF
--- a/site/src/views/Home.vue
+++ b/site/src/views/Home.vue
@@ -157,7 +157,7 @@ export default {
   },
   computed: {
     toplevel: function () {
-      return this.stats.tables.filter(table => (!table.table_name.includes('_')) && table.rows > 10000)
+      return this.stats.tables.filter(table => (!table.table_name.includes('_')))
     }
   },
   methods: {


### PR DESCRIPTION
This change allows the new metadata table to be included in the list of tables on the IATI Tables homepage, so that users know it is there, and can see the docs for its columns. The change is needed because the metadata table only has a single row so currently doesn't show up in the list.

Removing this part of the filter doesn't cause any other tables to be displayed which weren't already there.

Part of: https://github.com/codeforIATI/iati-tables/issues/3