### PR TITLE
Upgrade SQLAlchemy, add more type hints, minor restructure

### DIFF
--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -352,25 +352,6 @@ def process_registry() -> None:
     sql_process()
 
 
-def process_activities(activities, name):
-    create_activities_table()
-
-    get_standard()
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        logger.info("Converting to json")
-        with gzip.open(f"{tmpdirname}/out.csv.gz", "wt", newline="") as f:
-            csv_file = csv.writer(f)
-            save_converted_xml_to_csv(activities, csv_file, name, name)
-
-        with gzip.open(f"{tmpdirname}/out.csv.gz", "rt") as f:
-            csv_file_to_db(f)
-
-    activity_objects()
-    schema_analysis()
-    postgres_tables()
-
-
 def flatten_object(obj, current_path="", no_index_path=tuple()):
     for key, value in list(obj.items()):
         new_no_index_path = no_index_path + (key,)

--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -326,7 +326,7 @@ def load(processes: int, sample: Optional[int] = None) -> None:
     buckets = defaultdict(list)
     for num, dataset in enumerate(iatikit.data().datasets):
         buckets[num % processes].append(dataset)
-        if sample and num > sample:
+        if sample and num >= sample - 1:
             break
 
     logger.info("Loading registry data into database")

--- a/iatidata/sort_iati.py
+++ b/iatidata/sort_iati.py
@@ -30,6 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import sys
 from collections import OrderedDict
+from typing import Optional
 
 from lxml import etree as ET
 
@@ -117,7 +118,9 @@ class IATISchemaWalker(object):
                 )
         return child_tuples
 
-    def create_schema_dict(self, parent_name, parent_element=None):
+    def create_schema_dict(
+        self, parent_name: str, parent_element: Optional[ET._Element] = None
+    ) -> OrderedDict[str, OrderedDict]:
         """
         Created a nested OrderedDict representing the sturucture (and order!) of
         element in the IATI schema.

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 lxml
 xmlschema
-sqlalchemy<2
+sqlalchemy
 psycopg2-binary
 click
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,8 +83,10 @@ s3transfer==0.10.0
     # via boto3
 six==1.16.0
     # via python-dateutil
-sqlalchemy==1.4.51
+sqlalchemy==2.0.31
     # via -r requirements.in
+typing-extensions==4.12.2
+    # via sqlalchemy
 urllib3==2.0.7
     # via
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,6 @@ google-resumable-media==2.7.0
     # via google-cloud-bigquery
 googleapis-common-protos==1.62.0
     # via google-api-core
-greenlet==3.0.3
-    # via sqlalchemy
 iatikit==3.4.0
     # via -r requirements.in
 idna==3.6

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -6,7 +6,7 @@ isort
 flake8
 mypy
 types-requests
-lxml-stubs
+types-lxml
 sphinx
 sphinx-togglebutton
 sphinx-intl

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -216,7 +216,7 @@ sphinxcontrib-qthelp==1.0.7
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sqlalchemy==1.4.51
+sqlalchemy==2.0.31
     # via -r requirements.txt
 tomli==2.0.1
     # via
@@ -233,10 +233,12 @@ types-lxml==2024.4.14
     # via -r requirements_dev.in
 types-requests==2.31.0.20240125
     # via -r requirements_dev.in
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
+    #   -r requirements.txt
     #   black
     #   mypy
+    #   sqlalchemy
     #   types-lxml
 urllib3==2.0.7
     # via

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -42,6 +42,8 @@ configparser==6.0.0
     # via
     #   -r requirements.txt
     #   iatikit
+cssselect==1.2.0
+    # via types-lxml
 docutils==0.20.1
     # via
     #   sphinx
@@ -85,8 +87,6 @@ googleapis-common-protos==1.62.0
     # via
     #   -r requirements.txt
     #   google-api-core
-greenlet==3.0.3
-    # via -r requirements.txt
 iatikit==3.4.0
     # via -r requirements.txt
 idna==3.6
@@ -112,8 +112,6 @@ lxml==5.1.0
     # via
     #   -r requirements.txt
     #   iatikit
-lxml-stubs==0.5.1
-    # via -r requirements_dev.in
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
@@ -227,12 +225,19 @@ tomli==2.0.1
     #   pytest
 tornado==6.4
     # via livereload
+types-beautifulsoup4==4.12.0.20240511
+    # via types-lxml
+types-html5lib==1.1.11.20240228
+    # via types-beautifulsoup4
+types-lxml==2024.4.14
+    # via -r requirements_dev.in
 types-requests==2.31.0.20240125
     # via -r requirements_dev.in
 typing-extensions==4.9.0
     # via
     #   black
     #   mypy
+    #   types-lxml
 urllib3==2.0.7
     # via
     #   -r requirements.txt


### PR DESCRIPTION
- _No functionality changes_
- Upgrade to SQLAlchemy 2, and fix errors and deprecation warnings
- Add more type hints throughout
- Minor restructure (which involves renaming and splitting out a couple of functions) to clarify the main steps of the pipeline:
    - `extract` - fetch data from registry
    - `load` - load XML files into database
    - `process_registry` - transform data in the database into relational tables
    - `export_all` and `upload_all` - as before, export tables to various formats
