### PR TITLE
Refactor initial load step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ iati.sqlite
 iati.sqlite.gz
 iati.sqlite.zip
 stats.json
+profiles/
+logs/

--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -98,6 +98,16 @@ def create_activities_table():
         )
 
 
+@functools.lru_cache
+def get_activities_schema() -> xmlschema.XMLSchema10:
+    return xmlschema.XMLSchema(
+        str(
+            pathlib.Path()
+            / "__iatikitcache__/standard/schemas/203/iati-activities-schema.xsd"
+        )
+    )
+
+
 def get_standard(refresh=False):
     if not (pathlib.Path() / "__iatikitcache__").is_dir() or refresh:
         logger.info("Downloading standard")
@@ -238,12 +248,7 @@ def parse_activities_from_dataset(
         return
 
     transform = etree.XSLT(etree.parse(str(this_dir / "iati-activities.xsl")))
-    schema = xmlschema.XMLSchema(
-        str(
-            pathlib.Path()
-            / "__iatikitcache__/standard/schemas/203/iati-activities-schema.xsd"
-        )
-    )
+    schema = get_activities_schema()
 
     schema_dict = get_sorted_schema_dict()
 


### PR DESCRIPTION
Refactor logic for initially loading XML files into the database:

1. Instead of breaking the set of datasets up into buckets manually, pass the whole iterable to the `ProcessPoolExecutor` with `max_workers` set, so it will distribute them out to the workers. This is a more efficient use of the parallel processes, as previously it was likely that one or two of the manually-chunked buckets would take a lot longer than the others and waste time at the end.
2. Instead of writing to a temporary CSV file, write directly to the database, once per dataset/file. This is faster, makes the code easier to follow and removes reliance on order of columns.