### PR TITLE
FIX: Move database schema creation to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Run the code:
 ```
 export DATABASE_URL="postgresql://iatitables:PASSWORD_CHANGEME@localhost/iatitables"
 export IATI_TABLES_S3_DESTINATION=-
+export IATI_TABLES_SCHEMA=iati
 python -c 'import iatidata; iatidata.run_all(processes=6, sample=50)'
 ```
 

--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -321,7 +321,22 @@ def load_part(data: tuple[int, list[iatikit.Dataset]]) -> int:
     return bucket_num
 
 
+def create_database_schema():
+    if schema:
+        engine = get_engine()
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    f"""
+                    DROP schema IF EXISTS {schema} CASCADE;
+                    CREATE schema {schema};
+                    """
+                )
+            )
+
+
 def load(processes: int, sample: Optional[int] = None) -> None:
+    create_database_schema()
     create_activities_table()
 
     logger.info(f"Splitting data into {processes} buckets for loading")
@@ -339,18 +354,6 @@ def load(processes: int, sample: Optional[int] = None) -> None:
 
 
 def process_registry() -> None:
-    if schema:
-        engine = get_engine()
-        with engine.begin() as connection:
-            connection.execute(
-                text(
-                    f"""
-                    DROP schema IF EXISTS {schema} CASCADE;
-                    CREATE schema {schema};
-                    """
-                )
-            )
-
     activity_objects()
     schema_analysis()
     postgres_tables()


### PR DESCRIPTION
Schema must be created before any interaction with the database. I missed this locally as I didn't have the `IATI_TABLES_SCHEMA` environment variable set which is set on the live server.