### PR TITLE
Fix divide by zero error when exchange rate is zero

### DIFF
--- a/iatidata/__init__.py
+++ b/iatidata/__init__.py
@@ -905,6 +905,7 @@ def augment_transaction():
                 t._link,
                 case
                     when coalesce(value_currency, activity.defaultcurrency) = 'USD' then value
+                    when rate = 0 then null
                     else value / rate
                 end value_usd
             from


### PR DESCRIPTION
Fixes a division by zero error when upstream exchange rate is zero for a given currency.

In this case, treat it as thought the exchange rate is missing, and set the USD value to null.