### PR TITLE
Python deps: Upgrade iatikit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ httpx==0.28.1
     # via datasette
 hupper==1.12.1
     # via datasette
-iatikit==3.4.0
+iatikit==3.5.0
     # via iati-tables (pyproject.toml)
 idna==3.6
     # via

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -119,7 +119,7 @@ hupper==1.12.1
     # via datasette
 iati-sphinx-theme==3.0.0
     # via iati-tables (pyproject.toml)
-iatikit==3.4.0
+iatikit==3.5.0
     # via iati-tables (pyproject.toml)
 idna==3.6
     # via


### PR DESCRIPTION
We can't download schemas (due to https://github.com/codeforIATI/iatikit/issues/61 ) till we get the fix in 3.5.0 installed